### PR TITLE
spcast bug fixes

### DIFF
--- a/D&D misc/spcast/spcast.alias
+++ b/D&D misc/spcast/spcast.alias
@@ -14,16 +14,17 @@ homebrew = load_json(get_svar("brewspells", "[]")) + load_json(get("brewspells",
 if homebrew:
     for g in homebrew:
         gvar += load_json(get_gvar(g))
+spell = None
 for s in gvar:
     if args[0].lower() == s.name.lower():
         spell = s
         break
-if not spell:
+if spell is None:
     for s in gvar:
         if args[0].lower() in s.name.lower():
             spell = s
             break
-if not spell:
+if spell is None:
     return err("I don't think that's a supported spell.  Make sure it is spelled correctly and is in your `brewspells` if it's non-SRD.")
 if not ignore and spell.name not in character().spellbook:
     return err("I don't think you know that spell.  Make sure it is added to your spellbook or try to cast it again with `-i` to ignore requirements.")

--- a/D&D misc/spcast/spcast.alias
+++ b/D&D misc/spcast/spcast.alias
@@ -4,7 +4,7 @@ a = argparse(args)
 cc = "Spell Points"
 out = []
 ignore = a.get('-i')
-point_list = [0,2,3,4,5,6,7,8,9,10]
+point_list = [0,2,3,5,6,7,9,10,11,13]
 if not args:
     return f'''embed -title "Need some help casting a spell using Spell Points?" -desc 'Use `{ctx.prefix}{ctx.alias} "Spell Name"` to cast a spell using Spell Points instead of using Spell Slots (see the DMG p. 288 to learn more about this variant rule.)  This requires a counter named "Spell Points" and the spell must be in your spellbook (or use `-i` to ignore requirements). This uses `{ctx.prefix}cast` as a base command, so it accepts any argument that `{ctx.prefix}help cast` lists as available.  You may modify the points cost without changing the level of the spell by using `-p #`.' -f 'Want to add Homebrew spells?|Start by putting your spells in a tome on the [Avrae Dashboard](https://avrae.io/dashboard/homebrew/spells).  Export that tome to JSON and copy it to a new gvar.  You can remove everything except name and level of each spell to save space if you need to.  Take the address of that gvar and put it in a `uvar` called `brewspells`, formatted as a list (i.e. `{ctx.prefix}uvar brewspells ["01a1a2e8-6167-4bda-a513-45cfa56b26d4"]`, separating each address with a comma).  You can also make a tome available to a server by creating a server variable (`svar`) called `brewspells`, following the same format.' -footer "Alias by @R to the Ichie#6193"'''
 if not character().cc_exists(cc):


### PR DESCRIPTION
### Summary
Fuzzy matching was not working; partial spell names would throw an error because the spell variable was being assigned an int. Initializing it as None fixes that problem.

Also, the list of point values did not match the DMG so I fixed that as well.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
