### PR TITLE
Tactical Figther Superiority Dice fix

### DIFF
--- a/Star Wars 5e/level.gvar
+++ b/Star Wars 5e/level.gvar
@@ -1014,7 +1014,7 @@
 "classLevel": "FighterLevel",
 "reset": "short",
 "display": "bubble",
-"value": [0, 4, 4, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 10, 10, 10, 10, 10, 10],
+"value": [0, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5],
 "desc": "You have four superiority dice, instead of two, and you earn more at higher levels, as shown in the Superiority Dice column of the Tactical Specialist Combat Superiority table. This die changes as you gain fighter levels, as shown in the Combat Superiority column of the fighter table. A superiority die is expended when you use it. You regain all of your expended superiority dice when you finish a short or long rest."
 }]
 },


### PR DESCRIPTION
Instead of overwriting the original superiority dice counter, it was making a single counter and adding the two values together. This update should fix that by having the value for the Tactical Fighter Superiority Dice match that of the normal Fighter.