### PR TITLE
Sentindeldark WITHcraft changed to WITCHcraft

### DIFF
--- a/Star Wars 5e/level.gvar
+++ b/Star Wars 5e/level.gvar
@@ -3103,7 +3103,7 @@
 },
 {
 "Class": "Sentineldark",
-"subclass": "Withcraft",
+"subclass": "Witchcraft",
 "counters": [{
 "name": "Nature's Vigor",
 "level": 7,


### PR DESCRIPTION
Updated Sentineldark's Witchclass subclass to be properly spelled.